### PR TITLE
Switch to Boost unit test dynamic linking

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -5,6 +5,13 @@ endif()
 find_package(Boost 1.41 QUIET REQUIRED COMPONENTS filesystem system
   unit_test_framework)
 
+
+
+if(NOT Boost_USE_STATIC_LIBS)
+        add_definitions(-DBOOST_TEST_DYN_LINK=TRUE)
+endif()
+
+
 set(MVD2_TEST_FILE ${PROJECT_SOURCE_DIR}/tests/circuit.mvd2)
 set(MVD3_TEST_FILE ${PROJECT_SOURCE_DIR}/tests/circuit.mvd3)
 

--- a/tests/unit/tests_mvd2.cpp
+++ b/tests/unit/tests_mvd2.cpp
@@ -18,10 +18,12 @@
  */
 #include <mvd/mvd_base.hpp>
 #include <mvd/mvd2.hpp>
-#define BOOST_TEST_MAIN mvd2Parser
-#include <boost/test/included/unit_test.hpp>
 
 
+#define BOOST_TEST_MODULE mvd2Parser
+#define BOOST_TEST_MAIN
+
+#include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_CASE( parser_tests )
 {

--- a/tests/unit/tests_mvd3.cpp
+++ b/tests/unit/tests_mvd3.cpp
@@ -18,8 +18,10 @@
  */
 #include <mvd/mvd3.hpp>
 #include <mvd/mvd_generic.hpp>
+
 #define BOOST_TEST_MAIN mvd3Parser
 #include <boost/test/included/unit_test.hpp>
+
 
 
 


### PR DESCRIPTION
Plop Everybody

This brings two things:
- Much shorter compilation time for unit tests

- Fix issue with Boost >= 1.67 and GCC > 7.2 related to static string
initialization that causes Boost.unittest to segfault