### PR TITLE
Fix all listings and default to detected population

### DIFF
--- a/include/mvd/mvd_base.hpp
+++ b/include/mvd/mvd_base.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 #include <algorithm>
 #include <boost/multi_array.hpp>
 #include <boost/algorithm/string/predicate.hpp>

--- a/include/mvd/mvd_generic.hpp
+++ b/include/mvd/mvd_generic.hpp
@@ -60,7 +60,7 @@ inline MVDFile* open_mvd(const std::string & filename) {
 /// \return a shared pointer to a mvd::File object
 ///
 inline std::shared_ptr<File> open(const std::string& filename,
-                                  const std::string& population="default") {
+                                  const std::string& population="") {
     std::shared_ptr<File> mvdfile;
     switch(_mvd_format(filename)) {
         case MVDType::MVD2:

--- a/python/mvdtool.cpp
+++ b/python/mvdtool.cpp
@@ -111,7 +111,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
     py::module mvd3 = mvd.def_submodule("MVD3", "Support for the MVD3 format");
     py::module sonata = mvd.def_submodule("sonata", "Support for the SONATA format");
 
-    mvd.def("open", &open, "filename"_a, "population"_a = "default");
+    mvd.def("open", &open, "filename"_a, "population"_a = "");
 
     py::class_<File, PyFile> file(mvd, "__File");
     file

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,9 +2,8 @@ if(NOT BUILD_UNIT_TESTS)
   return()
 endif()
 
-find_package(Boost 1.41 QUIET REQUIRED COMPONENTS filesystem system
-  unit_test_framework)
-
+find_package(Boost 1.41 QUIET REQUIRED COMPONENTS
+             filesystem system unit_test_framework)
 
 
 if(NOT Boost_USE_STATIC_LIBS)


### PR DESCRIPTION
Fix 1: Auto-population should be the default
Fix 2: In some sonata files we get
```
>>> mvd.all_etypes
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: No such enumeration attribute: 'etype'
```

This is because the standard doesn't require the enumerations, as in mvd3
In those cases we should get all values and return a list without duplicates
```
>>> mvd.all_etypes
['bAC', 'bIR', 'bNAC', 'bSTUT', 'cACint', 'cIR', 'cNAC', 'cSTUT', 'dNAC', 'dSTUT', 'cADpyr']
```