### PR TITLE
Fix issue with calling pybind functions with one argument

### DIFF
--- a/include/mvdtool/bits/mvd3_misc.hpp
+++ b/include/mvdtool/bits/mvd3_misc.hpp
@@ -35,11 +35,12 @@ template <typename T>
 inline std::vector<T> get_data_for_selection(const HighFive::DataSet& dataset,
                                              const MVD3::Range& range) {
     std::vector<T> data_values;
+    const size_t n_elem = dataset.getSpace().getDimensions()[0];
 
     if (!range.is_empty()) {
         dataset.select({range.offset}, {range.count}).read(data_values);
     } else {
-        dataset.read(data_values);
+        dataset.select({range.offset}, {n_elem - range.offset}).read(data_values);
     }
     return data_values;
 }
@@ -173,9 +174,10 @@ inline Positions MVD3File::getPositions(const Range& range) const {
     HighFive::DataSet set = _hdf5_file.getDataSet(did_cells_positions);
     if (!range.is_empty()) {
         set.select({range.offset, 0}, {range.count, 3}).read(res);
-        return res;
+    } else {
+        const auto size = set.getSpace().getDimensions()[0];
+        set.select({range.offset, 0}, {size - range.offset, 3}).read(res);
     }
-    set.read(res);
     return res;
 }
 
@@ -185,9 +187,10 @@ inline Rotations MVD3File::getRotations(const Range& range) const {
     HighFive::DataSet set = _hdf5_file.getDataSet(did_cells_rotations);
     if (!range.is_empty()) {
         set.select({range.offset, 0}, {range.count, 4}).read(res);
-        return res;
+    } else {
+        const auto size = set.getSpace().getDimensions()[0];
+        set.select({range.offset, 0}, {size - range.offset, 4}).read(res);
     }
-    set.read(res);
     return res;
 }
 

--- a/include/mvdtool/bits/mvd3_misc.hpp
+++ b/include/mvdtool/bits/mvd3_misc.hpp
@@ -37,11 +37,7 @@ inline std::vector<T> get_data_for_selection(const HighFive::DataSet& dataset,
     std::vector<T> data_values;
     const size_t n_elem = dataset.getSpace().getDimensions()[0];
 
-    if (!range.is_empty()) {
-        dataset.select({range.offset}, {range.count}).read(data_values);
-    } else {
-        dataset.select({range.offset}, {n_elem - range.offset}).read(data_values);
-    }
+    dataset.select({range.offset}, {range.adjust_count(n_elem)}).read(data_values);
     return data_values;
 }
 
@@ -85,8 +81,9 @@ std::vector<T> tsv_get_chunked(const MVD3::MVD3File& mvd,
                                const MVD3::Range& range) {
     const size_t CHUNK_SIZE = 256;
     std::vector<T> output;
-    const size_t end = range.is_empty()? mvd.getNbNeuron() : range.offset + range.count;
-    output.reserve(end - range.offset);
+    const size_t total_size = mvd.getNbNeuron();
+    const size_t end = range.calculate_end(total_size);
+    output.reserve(range.adjust_count(total_size));
 
     for (auto index = range.offset; index < end; index += CHUNK_SIZE) {
         const MVD::Range subrange(index, std::min(CHUNK_SIZE, end - index));
@@ -172,12 +169,8 @@ inline size_t MVD3File::getNbNeuron() const {
 inline Positions MVD3File::getPositions(const Range& range) const {
     Positions res;
     HighFive::DataSet set = _hdf5_file.getDataSet(did_cells_positions);
-    if (!range.is_empty()) {
-        set.select({range.offset, 0}, {range.count, 3}).read(res);
-    } else {
-        const auto size = set.getSpace().getDimensions()[0];
-        set.select({range.offset, 0}, {size - range.offset, 3}).read(res);
-    }
+    const auto size = set.getSpace().getDimensions()[0];
+    set.select({range.offset, 0}, {range.adjust_count(size), 3}).read(res);
     return res;
 }
 
@@ -185,12 +178,8 @@ inline Positions MVD3File::getPositions(const Range& range) const {
 inline Rotations MVD3File::getRotations(const Range& range) const {
     Rotations res;
     HighFive::DataSet set = _hdf5_file.getDataSet(did_cells_rotations);
-    if (!range.is_empty()) {
-        set.select({range.offset, 0}, {range.count, 4}).read(res);
-    } else {
-        const auto size = set.getSpace().getDimensions()[0];
-        set.select({range.offset, 0}, {size - range.offset, 4}).read(res);
-    }
+    const auto size = set.getSpace().getDimensions()[0];
+    set.select({range.offset, 0}, {range.adjust_count(size), 4}).read(res);
     return res;
 }
 

--- a/include/mvdtool/bits/sonata_misc.hpp
+++ b/include/mvdtool/bits/sonata_misc.hpp
@@ -100,14 +100,15 @@ inline SonataFile::SonataFile(const std::string &filename, const std::string &po
 inline void SonataFile::openComboTsv(const std::string&) {}
 
 inline Positions SonataFile::getPositions(const Range &range) const {
-    Positions res{boost::extents[range.count > 0 ? range.count : size_][3]};
+    const auto range_count = range.count > 0 ? range.count : size_ - range.offset;
+    Positions res{boost::extents[range_count][3]};
 
     auto xs = pop_->getAttribute<double>("x", select(range, size_));
     auto ys = pop_->getAttribute<double>("y", select(range, size_));
     auto zs = pop_->getAttribute<double>("z", select(range, size_));
 
     // No direct slicing write access from std::vector
-    for (size_t i = 0; i < (range.count > 0 ? range.count : size_); ++i) {
+    for (size_t i = 0; i < range_count; ++i) {
         res[i][0] = xs[i];
         res[i][1] = ys[i];
         res[i][2] = zs[i];
@@ -117,7 +118,8 @@ inline Positions SonataFile::getPositions(const Range &range) const {
 }
 
 inline Rotations SonataFile::getQuaternionRotations(const Range &range) const {
-    Positions res{boost::extents[range.count > 0 ? range.count : size_][4]};
+    const auto range_count = range.count > 0 ? range.count : size_ - range.offset;
+    Positions res{boost::extents[range_count][4]};
 
     auto xs = pop_->getAttribute<double>("orientation_x", select(range, size_));
     auto ys = pop_->getAttribute<double>("orientation_y", select(range, size_));
@@ -125,7 +127,7 @@ inline Rotations SonataFile::getQuaternionRotations(const Range &range) const {
     auto ws = pop_->getAttribute<double>("orientation_w", select(range, size_));
 
     // No direct slicing write access from std::vector
-    for (size_t i = 0; i < (range.count > 0 ? range.count : size_); ++i) {
+    for (size_t i = 0; i < range_count; ++i) {
         res[i][0] = xs[i];
         res[i][1] = ys[i];
         res[i][2] = zs[i];
@@ -138,14 +140,15 @@ inline Rotations SonataFile::getQuaternionRotations(const Range &range) const {
 inline Rotations SonataFile::getAngularRotations(const Range &range) const {
     using Quaternion = boost::math::quaternion<double>;
 
-    Positions res{boost::extents[range.count > 0 ? range.count : size_][4]};
+    const auto range_count = range.count > 0 ? range.count : size_ - range.offset;
+    Positions res{boost::extents[range_count][4]};
 
     const auto attrs = pop_->attributeNames();
     const bool use_x = attrs.count("rotation_angle_xaxis") > 0;
     const bool use_y = attrs.count("rotation_angle_yaxis") > 0;
     const bool use_z = attrs.count("rotation_angle_zaxis") > 0;
 
-    for (size_t i = 0; i < (range.count > 0 ? range.count : size_); ++i) {
+    for (size_t i = 0; i < range_count; ++i) {
         Quaternion rot{1., 0., 0., 0.};
         Range r{range.offset + i, 1};
 

--- a/include/mvdtool/bits/sonata_misc.hpp
+++ b/include/mvdtool/bits/sonata_misc.hpp
@@ -48,8 +48,7 @@ const std::string did_holding_current = "holding_current";
 const std::string did_model_template = "model_template";
 
 inline auto select(const MVD::Range& range, size_t size) {
-    auto range_end = (range.count > 0)? range.offset + range.count : size;
-    return sonata::Selection({{range.offset, range_end}});
+    return sonata::Selection({{range.offset, range.calculate_end(size)}});
 }
 
 
@@ -100,15 +99,15 @@ inline SonataFile::SonataFile(const std::string &filename, const std::string &po
 inline void SonataFile::openComboTsv(const std::string&) {}
 
 inline Positions SonataFile::getPositions(const Range &range) const {
-    const auto range_count = range.count > 0 ? range.count : size_ - range.offset;
-    Positions res{boost::extents[range_count][3]};
+    const auto adjusted_count = range.adjust_count(size_);
+    Positions res{boost::extents[adjusted_count][3]};
 
     auto xs = pop_->getAttribute<double>("x", select(range, size_));
     auto ys = pop_->getAttribute<double>("y", select(range, size_));
     auto zs = pop_->getAttribute<double>("z", select(range, size_));
 
     // No direct slicing write access from std::vector
-    for (size_t i = 0; i < range_count; ++i) {
+    for (size_t i = 0; i < adjusted_count; ++i) {
         res[i][0] = xs[i];
         res[i][1] = ys[i];
         res[i][2] = zs[i];
@@ -118,8 +117,8 @@ inline Positions SonataFile::getPositions(const Range &range) const {
 }
 
 inline Rotations SonataFile::getQuaternionRotations(const Range &range) const {
-    const auto range_count = range.count > 0 ? range.count : size_ - range.offset;
-    Positions res{boost::extents[range_count][4]};
+    const auto adjusted_count = range.adjust_count(size_);
+    Positions res{boost::extents[adjusted_count][4]};
 
     auto xs = pop_->getAttribute<double>("orientation_x", select(range, size_));
     auto ys = pop_->getAttribute<double>("orientation_y", select(range, size_));
@@ -127,7 +126,7 @@ inline Rotations SonataFile::getQuaternionRotations(const Range &range) const {
     auto ws = pop_->getAttribute<double>("orientation_w", select(range, size_));
 
     // No direct slicing write access from std::vector
-    for (size_t i = 0; i < range_count; ++i) {
+    for (size_t i = 0; i < adjusted_count; ++i) {
         res[i][0] = xs[i];
         res[i][1] = ys[i];
         res[i][2] = zs[i];
@@ -140,15 +139,15 @@ inline Rotations SonataFile::getQuaternionRotations(const Range &range) const {
 inline Rotations SonataFile::getAngularRotations(const Range &range) const {
     using Quaternion = boost::math::quaternion<double>;
 
-    const auto range_count = range.count > 0 ? range.count : size_ - range.offset;
-    Positions res{boost::extents[range_count][4]};
+    const auto adjusted_count = range.adjust_count(size_);
+    Positions res{boost::extents[adjusted_count][4]};
 
     const auto attrs = pop_->attributeNames();
     const bool use_x = attrs.count("rotation_angle_xaxis") > 0;
     const bool use_y = attrs.count("rotation_angle_yaxis") > 0;
     const bool use_z = attrs.count("rotation_angle_zaxis") > 0;
 
-    for (size_t i = 0; i < range_count; ++i) {
+    for (size_t i = 0; i < adjusted_count; ++i) {
         Quaternion rot{1., 0., 0., 0.};
         Range r{range.offset + i, 1};
 

--- a/include/mvdtool/mvd_base.hpp
+++ b/include/mvdtool/mvd_base.hpp
@@ -50,7 +50,8 @@ public:
     inline Range(const size_t offset_=0, const size_t count_=0) : offset(offset_), count(count_) {}
 
     inline static Range all() { return Range(0,0); }
-    inline bool is_empty() const { return count == 0; }
+    inline size_t adjust_count(const size_t total_range) const { return count > 0 ? count : total_range - offset; }
+    inline size_t calculate_end(const size_t total_range) const { return count > 0 ? offset + count : total_range; }
     size_t offset;
     size_t count;
 };

--- a/python/mvdtool.cpp
+++ b/python/mvdtool.cpp
@@ -143,6 +143,11 @@ PYBIND11_MODULE(mvdtool, mvd) {
                 f.openComboTsv(filename);
              },
              "filename"_a)
+        .def("positions", [](const File& f, int offset) {
+                auto res = f.getPositions(Range(offset, 1));
+                return py::array({res.shape()[0], res.shape()[1]}, res.data());
+             },
+             "offset"_a)
         .def("positions", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getPositions(r);
@@ -150,6 +155,11 @@ PYBIND11_MODULE(mvdtool, mvd) {
              },
              "offset"_a = 0,
              "count"_a = 0)
+        .def("rotations", [](const File& f, int offset) {
+                auto res = f.getRotations(Range(offset, 1));
+                return py::array({res.shape()[0], res.shape()[1]}, res.data());
+             },
+             "offset"_a)
         .def("rotations", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getRotations(r);
@@ -157,6 +167,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
              },
              "offset"_a = 0,
              "count"_a = 0)
+        .def("etypes", [](const File& f, int offset) {
+                return f.getEtypes(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("etypes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getEtypes(r);
@@ -167,6 +181,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
                 const auto& func = [&f](const MVD::Range& r){return f.getEtypes(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("mtypes", [](const File& f, int offset) {
+                return f.getMtypes(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("mtypes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getMtypes(r);
@@ -177,6 +195,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
                 const auto& func = [&f](const MVD::Range& r){return f.getMtypes(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("emodels", [](const File& f, int offset) {
+                return f.getEmodels(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("emodels", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getEmodels(r);
@@ -187,6 +209,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
                 const auto& func = [&f](const MVD::Range& r){return f.getEmodels(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("threshold_currents", [](const File& f, int offset) {
+                return f.getThresholdCurrents(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("threshold_currents", [](const File& f, int offset, int count) {
                 auto res = f.getThresholdCurrents(Range(offset, count));
                 return py::array(res.size(), res.data());
@@ -198,6 +224,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
                 auto values = _atIndices<double>(func, f.size(), idx);
                 return py::array(values.size(), values.data());
              })
+        .def("holding_currents", [](const File& f, int offset) {
+                return f.getHoldingCurrents(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("holding_currents", [](const File& f, int offset, int count) {
                 auto res = f.getHoldingCurrents(Range(offset, count));
                 return py::array(res.size(), res.data());
@@ -209,6 +239,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
                 auto values = _atIndices<double>(func, f.size(), idx);
                 return py::array(values.size(), values.data());
              })
+        .def("morphologies", [](const File& f, int offset) {
+                return f.getMorphologies(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("morphologies", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getMorphologies(r);
@@ -219,6 +253,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
                 const auto& func = [&f](const MVD::Range& r){return f.getMorphologies(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("synapse_classes", [](const File& f, int offset) {
+                return f.getSynapseClass(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("synapse_classes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getSynapseClass(r);
@@ -229,6 +267,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
                 const auto& func = [&f](const MVD::Range& r){return f.getSynapseClass(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("regions", [](const File& f, int offset) {
+                return f.getRegions(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("regions", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getRegions(r);
@@ -239,6 +281,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
                 const auto& func = [&f](const MVD::Range& r){return f.getRegions(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("raw_etypes", [](const File& f, int offset) {
+                return f.getIndexEtypes(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("raw_etypes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexEtypes(r);
@@ -246,6 +292,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
              },
              "offset"_a = 0,
              "count"_a = 0)
+        .def("raw_mtypes", [](const File& f, int offset) {
+                return f.getIndexMtypes(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("raw_mtypes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexMtypes(r);
@@ -253,6 +303,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
              },
              "offset"_a = 0,
              "count"_a = 0)
+        .def("raw_synapse_classes", [](const File& f, int offset) {
+                return f.getIndexSynapseClass(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("raw_synapse_classes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexSynapseClass(r);
@@ -260,6 +314,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
              },
              "offset"_a = 0,
              "count"_a = 0)
+        .def("raw_regions", [](const File& f, int offset) {
+                return f.getIndexRegions(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("raw_regions", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexRegions(r);
@@ -278,6 +336,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
 
     py::class_<MVD3File, std::shared_ptr<MVD3File>>(mvd3, "File", file)
         .def(py::init<const std::string&>())
+        .def("raw_morphologies", [](const MVD3File& f, int offset) {
+                return f.getIndexMorphologies(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("raw_morphologies", [](const MVD3File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexMorphologies(r);
@@ -285,6 +347,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
              },
              "offset"_a = 0,
              "count"_a = 0)
+        .def("me_combos", [](const MVD3File& f, int offset) {
+                return f.getMECombos(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("me_combos", [](const MVD3File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getMECombos(r);
@@ -295,6 +361,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
                 const auto& func = [&f](const MVD::Range& r){return f.getMECombos(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("layers", [](const MVD3File& f, int offset) {
+                return f.getLayers(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("layers", [](const MVD3File& f, int offset, int count) {
                 return f.getLayers(Range(offset, count));
              },
@@ -309,6 +379,10 @@ PYBIND11_MODULE(mvdtool, mvd) {
 
     py::class_<SonataFile, std::shared_ptr<SonataFile>>(sonata, "File", file)
         .def(py::init<const std::string&>())
+        .def("layers", [](const SonataFile& f, int offset) {
+                return f.getLayers(Range(offset, 1))[0];
+             },
+             "offset"_a)
         .def("layers", [](const SonataFile& f, int offset, int count) {
                 return f.getLayers(Range(offset, count));
              },

--- a/python/mvdtool.cpp
+++ b/python/mvdtool.cpp
@@ -142,123 +142,151 @@ PYBIND11_MODULE(mvdtool, mvd) {
         .def("open_combo_tsv", [](File& f, const std::string & filename) {
                 f.openComboTsv(filename);
              })
+        .def("positions", [](const File& f) {
+                auto res = f.getPositions(Range::all());
+                return py::array({res.shape()[0], res.shape()[1]}, res.data());
+             })
         .def("positions", [](const File& f, int offset) {
-                auto res = f.getPositions(Range(offset, 1));
+                Range r(offset, 1);
+                auto res = f.getPositions(r);
                 return py::array({res.shape()[0], res.shape()[1]}, res.data());
              })
         .def("positions", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getPositions(r);
                 return py::array({res.shape()[0], res.shape()[1]}, res.data());
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
+        .def("rotations", [](const File& f) {
+                auto res = f.getRotations(Range::all());
+                return py::array({res.shape()[0], res.shape()[1]}, res.data());
+             })
         .def("rotations", [](const File& f, int offset) {
-                auto res = f.getRotations(Range(offset, 1));
+                Range r(offset, 1);
+                auto res = f.getRotations(r);
                 return py::array({res.shape()[0], res.shape()[1]}, res.data());
              })
         .def("rotations", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getRotations(r);
                 return py::array({res.shape()[0], res.shape()[1]}, res.data());
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
+        .def("etypes", [](const File& f) {
+                return f.getEtypes(Range::all());
+             })
         .def("etypes", [](const File& f, int offset) {
-                return f.getEtypes(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getEtypes(r)[0];
              })
         .def("etypes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getEtypes(r);
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
         .def("etypes", [](const File& f, pyarray<size_t> idx) {
                 const auto& func = [&f](const MVD::Range& r){return f.getEtypes(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("mtypes", [](const File& f) {
+                return f.getMtypes(Range::all());
+             })
         .def("mtypes", [](const File& f, int offset) {
-                return f.getMtypes(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getMtypes(r)[0];
              })
         .def("mtypes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getMtypes(r);
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
         .def("mtypes", [](const File& f, pyarray<size_t> idx) {
                 const auto& func = [&f](const MVD::Range& r){return f.getMtypes(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("emodels", [](const File& f) {
+                return f.getEmodels(Range::all());
+             })
         .def("emodels", [](const File& f, int offset) {
-                return f.getEmodels(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getEmodels(r)[0];
              })
         .def("emodels", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getEmodels(r);
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
         .def("emodels", [](const File& f, pyarray<size_t> idx) {
                 const auto& func = [&f](const MVD::Range& r){return f.getEmodels(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("threshold_currents", [](const File& f) {
+                auto res = f.getThresholdCurrents(Range::all());
+                return py::array(res.size(), res.data());
+             })
         .def("threshold_currents", [](const File& f, int offset) {
-                return f.getThresholdCurrents(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getThresholdCurrents(r)[0];
              })
         .def("threshold_currents", [](const File& f, int offset, int count) {
-                auto res = f.getThresholdCurrents(Range(offset, count));
+                Range r(offset, count);
+                auto res = f.getThresholdCurrents(r);
                 return py::array(res.size(), res.data());
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
         .def("threshold_currents", [](const File& f, pyarray<size_t> idx) {
                 const auto& func = [&f](const MVD::Range& r){return f.getThresholdCurrents(r);};
                 auto values = _atIndices<double>(func, f.size(), idx);
                 return py::array(values.size(), values.data());
              })
+        .def("holding_currents", [](const File& f) {
+                auto res = f.getHoldingCurrents(Range::all());
+                return py::array(res.size(), res.data());
+             })
         .def("holding_currents", [](const File& f, int offset) {
-                return f.getHoldingCurrents(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getHoldingCurrents(r)[0];
              })
         .def("holding_currents", [](const File& f, int offset, int count) {
-                auto res = f.getHoldingCurrents(Range(offset, count));
+                Range r(offset, count);
+                auto res = f.getHoldingCurrents(r);
                 return py::array(res.size(), res.data());
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
         .def("holding_currents", [](const File& f, pyarray<size_t> idx) {
                 const auto& func = [&f](const MVD::Range& r){return f.getHoldingCurrents(r);};
                 auto values = _atIndices<double>(func, f.size(), idx);
                 return py::array(values.size(), values.data());
              })
+        .def("morphologies", [](const File& f) {
+                return f.getMorphologies(Range::all());
+             })
         .def("morphologies", [](const File& f, int offset) {
-                return f.getMorphologies(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getMorphologies(r)[0];
              })
         .def("morphologies", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getMorphologies(r);
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
         .def("morphologies", [](const File& f, pyarray<size_t> idx) {
                 const auto& func = [&f](const MVD::Range& r){return f.getMorphologies(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("synapse_classes", [](const File& f) {
+                return f.getSynapseClass(Range::all());
+             })
         .def("synapse_classes", [](const File& f, int offset) {
-                return f.getSynapseClass(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getSynapseClass(r)[0];
              })
         .def("synapse_classes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getSynapseClass(r);
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
         .def("synapse_classes", [](const File& f, pyarray<size_t> idx) {
                 const auto& func = [&f](const MVD::Range& r){return f.getSynapseClass(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("regions", [](const File& f) {
+                return f.getRegions(Range::all());
+             })
         .def("regions", [](const File& f, int offset) {
-                return f.getRegions(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getRegions(r)[0];
              })
         .def("regions", [](const File& f, int offset, int count) {
                 Range r(offset, count);
@@ -270,46 +298,58 @@ PYBIND11_MODULE(mvdtool, mvd) {
                 const auto& func = [&f](const MVD::Range& r){return f.getRegions(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("raw_etypes", [](const File& f) {
+                auto res = f.getIndexEtypes(Range::all());
+                return py::array(res.size(), res.data());
+             })
         .def("raw_etypes", [](const File& f, int offset) {
-                return f.getIndexEtypes(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getIndexEtypes(r)[0];
              })
         .def("raw_etypes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexEtypes(r);
                 return py::array(res.size(), res.data());
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
+        .def("raw_mtypes", [](const File& f) {
+                auto res = f.getIndexMtypes(Range::all());
+                return py::array(res.size(), res.data());
+             })
         .def("raw_mtypes", [](const File& f, int offset) {
-                return f.getIndexMtypes(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getIndexMtypes(r)[0];
              })
         .def("raw_mtypes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexMtypes(r);
                 return py::array(res.size(), res.data());
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
+        .def("raw_synapse_classes", [](const File& f) {
+                auto res = f.getIndexSynapseClass(Range::all());
+                return py::array(res.size(), res.data());
+             })
         .def("raw_synapse_classes", [](const File& f, int offset) {
-                return f.getIndexSynapseClass(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getIndexSynapseClass(r)[0];
              })
         .def("raw_synapse_classes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexSynapseClass(r);
                 return py::array(res.size(), res.data());
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
+        .def("raw_regions", [](const File& f) {
+                auto res = f.getIndexRegions(Range::all());
+                return py::array(res.size(), res.data());
+             })
         .def("raw_regions", [](const File& f, int offset) {
-                return f.getIndexRegions(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getIndexRegions(r)[0];
              })
         .def("raw_regions", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexRegions(r);
                 return py::array(res.size(), res.data());
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
         .def("hasCurrents", &File::hasCurrents)
         .def_property_readonly("rotated", &File::hasRotations)
         .def_property_readonly("all_etypes", &File::listAllEtypes)
@@ -321,37 +361,45 @@ PYBIND11_MODULE(mvdtool, mvd) {
 
     py::class_<MVD3File, std::shared_ptr<MVD3File>>(mvd3, "File", file)
         .def(py::init<const std::string&>())
+        .def("raw_morphologies", [](const MVD3File& f) {
+                auto res = f.getIndexMorphologies(Range::all());
+                return py::array(res.size(), res.data());
+             })
         .def("raw_morphologies", [](const MVD3File& f, int offset) {
-                return f.getIndexMorphologies(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getIndexMorphologies(r)[0];
              })
         .def("raw_morphologies", [](const MVD3File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexMorphologies(r);
                 return py::array(res.size(), res.data());
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
+        .def("me_combos", [](const MVD3File& f) {
+                return f.getMECombos(Range::all());
+             })
         .def("me_combos", [](const MVD3File& f, int offset) {
-                return f.getMECombos(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getMECombos(r)[0];
              })
         .def("me_combos", [](const MVD3File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getMECombos(r);
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+             })
         .def("me_combos", [](const MVD3File& f, pyarray<size_t> idx) {
                 const auto& func = [&f](const MVD::Range& r){return f.getMECombos(r);};
                 return _atIndices<std::string>(func, f.size(), idx);
              })
+        .def("layers", [](const MVD3File& f) {
+                return f.getLayers(Range::all());
+             })
         .def("layers", [](const MVD3File& f, int offset) {
-                return f.getLayers(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getLayers(r)[0];
              })
         .def("layers", [](const MVD3File& f, int offset, int count) {
-                return f.getLayers(Range(offset, count));
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+                Range r(offset, count);
+                return f.getLayers(r);
+             })
         .def("layers", [](const MVD3File& f, pyarray<size_t> idx) {
                 const auto& func = [&f](const MVD::Range& r){return f.getLayers(r);};
                 return _atIndices<boost::int32_t>(func, f.size(), idx);
@@ -361,14 +409,17 @@ PYBIND11_MODULE(mvdtool, mvd) {
 
     py::class_<SonataFile, std::shared_ptr<SonataFile>>(sonata, "File", file)
         .def(py::init<const std::string&>())
+        .def("layers", [](const SonataFile& f) {
+                return f.getLayers(Range::all());
+             })
         .def("layers", [](const SonataFile& f, int offset) {
-                return f.getLayers(Range(offset, 1))[0];
+                Range r(offset, 1);
+                return f.getLayers(r)[0];
              })
         .def("layers", [](const SonataFile& f, int offset, int count) {
-                return f.getLayers(Range(offset, count));
-             },
-             "offset"_a = 0,
-             "count"_a = 0)
+                Range r(offset, count);
+                return f.getLayers(r);
+             })
         .def("layers", [](const SonataFile& f, pyarray<size_t> idx) {
                 const auto& func = [&f](const MVD::Range& r){return f.getLayers(r);};
                 return _atIndices<std::string>(func, f.size(), idx);

--- a/python/mvdtool.cpp
+++ b/python/mvdtool.cpp
@@ -141,13 +141,11 @@ PYBIND11_MODULE(mvdtool, mvd) {
         .def("__len__", &File::size)
         .def("open_combo_tsv", [](File& f, const std::string & filename) {
                 f.openComboTsv(filename);
-             },
-             "filename"_a)
+             })
         .def("positions", [](const File& f, int offset) {
                 auto res = f.getPositions(Range(offset, 1));
                 return py::array({res.shape()[0], res.shape()[1]}, res.data());
-             },
-             "offset"_a)
+             })
         .def("positions", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getPositions(r);
@@ -158,8 +156,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
         .def("rotations", [](const File& f, int offset) {
                 auto res = f.getRotations(Range(offset, 1));
                 return py::array({res.shape()[0], res.shape()[1]}, res.data());
-             },
-             "offset"_a)
+             })
         .def("rotations", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getRotations(r);
@@ -169,8 +166,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              "count"_a = 0)
         .def("etypes", [](const File& f, int offset) {
                 return f.getEtypes(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("etypes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getEtypes(r);
@@ -183,8 +179,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              })
         .def("mtypes", [](const File& f, int offset) {
                 return f.getMtypes(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("mtypes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getMtypes(r);
@@ -197,8 +192,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              })
         .def("emodels", [](const File& f, int offset) {
                 return f.getEmodels(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("emodels", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getEmodels(r);
@@ -211,8 +205,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              })
         .def("threshold_currents", [](const File& f, int offset) {
                 return f.getThresholdCurrents(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("threshold_currents", [](const File& f, int offset, int count) {
                 auto res = f.getThresholdCurrents(Range(offset, count));
                 return py::array(res.size(), res.data());
@@ -226,8 +219,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              })
         .def("holding_currents", [](const File& f, int offset) {
                 return f.getHoldingCurrents(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("holding_currents", [](const File& f, int offset, int count) {
                 auto res = f.getHoldingCurrents(Range(offset, count));
                 return py::array(res.size(), res.data());
@@ -241,8 +233,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              })
         .def("morphologies", [](const File& f, int offset) {
                 return f.getMorphologies(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("morphologies", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getMorphologies(r);
@@ -255,8 +246,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              })
         .def("synapse_classes", [](const File& f, int offset) {
                 return f.getSynapseClass(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("synapse_classes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getSynapseClass(r);
@@ -269,8 +259,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              })
         .def("regions", [](const File& f, int offset) {
                 return f.getRegions(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("regions", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getRegions(r);
@@ -283,8 +272,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              })
         .def("raw_etypes", [](const File& f, int offset) {
                 return f.getIndexEtypes(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("raw_etypes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexEtypes(r);
@@ -294,8 +282,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              "count"_a = 0)
         .def("raw_mtypes", [](const File& f, int offset) {
                 return f.getIndexMtypes(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("raw_mtypes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexMtypes(r);
@@ -305,8 +292,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              "count"_a = 0)
         .def("raw_synapse_classes", [](const File& f, int offset) {
                 return f.getIndexSynapseClass(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("raw_synapse_classes", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexSynapseClass(r);
@@ -316,8 +302,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              "count"_a = 0)
         .def("raw_regions", [](const File& f, int offset) {
                 return f.getIndexRegions(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("raw_regions", [](const File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexRegions(r);
@@ -338,8 +323,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
         .def(py::init<const std::string&>())
         .def("raw_morphologies", [](const MVD3File& f, int offset) {
                 return f.getIndexMorphologies(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("raw_morphologies", [](const MVD3File& f, int offset, int count) {
                 Range r(offset, count);
                 auto res = f.getIndexMorphologies(r);
@@ -349,8 +333,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              "count"_a = 0)
         .def("me_combos", [](const MVD3File& f, int offset) {
                 return f.getMECombos(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("me_combos", [](const MVD3File& f, int offset, int count) {
                 Range r(offset, count);
                 return f.getMECombos(r);
@@ -363,8 +346,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
              })
         .def("layers", [](const MVD3File& f, int offset) {
                 return f.getLayers(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("layers", [](const MVD3File& f, int offset, int count) {
                 return f.getLayers(Range(offset, count));
              },
@@ -381,8 +363,7 @@ PYBIND11_MODULE(mvdtool, mvd) {
         .def(py::init<const std::string&>())
         .def("layers", [](const SonataFile& f, int offset) {
                 return f.getLayers(Range(offset, 1))[0];
-             },
-             "offset"_a)
+             })
         .def("layers", [](const SonataFile& f, int offset, int count) {
                 return f.getLayers(Range(offset, count));
              },

--- a/python/test/test_mvd3.py
+++ b/python/test/test_mvd3.py
@@ -28,6 +28,12 @@ def test_position_values(circuit):
     assert numpy.allclose(posics[0], [40.821_401, 1986.506_637, 10.788_424])
 
 
+def test_position_value(circuit):
+    posic_0 = circuit.positions(0)
+    assert posic_0.shape[0] == 1
+    assert numpy.allclose(posic_0, [40.821_401, 1986.506_637, 10.788_424])
+
+
 def test_rotation_values(circuit):
     assert circuit.rotated
 
@@ -35,6 +41,15 @@ def test_rotation_values(circuit):
     assert posics.shape[0] == 1000
     assert numpy.allclose(posics[0], [0, -0.010_005_561, 0, 0.999_949_943])
     assert numpy.allclose(posics[20], [0, 0.923_706, 0, 0.383_102])
+
+
+def test_rotation_value(circuit):
+    assert circuit.rotated
+
+    posic_0 = circuit.rotations(0)
+    assert posic_0.shape[0] == 1
+    assert numpy.allclose(posic_0, [0, -0.010_005_561, 0, 0.999_949_943])
+
 
 def test_position_range(circuit):
     posics = circuit.positions()
@@ -50,6 +65,12 @@ def test_morphology_values(circuit):
     assert morphos[0] == "sm090227a1-2_idC"
     assert morphos[20] == "dend-C280998A-P3_axon-sm110131a1-3_INT_idA"
     assert morphos[21] == "dend-rr110114C1_idA_axon-sm110131a1-3_INT_idA"
+
+
+def test_morphology_value(circuit):
+    morpho = circuit.morphologies(0)
+
+    assert morpho == "sm090227a1-2_idC"
 
 
 def test_morphology_values_indices(circuit):
@@ -106,6 +127,12 @@ def test_classes_values(circuit):
     assert classes[0] == "INH"
     assert classes[10] == "INH"
     assert classes[20] == "EXC"
+
+
+def test_raw_etype(circuit):
+    raw_etype = circuit.raw_etypes(22)
+
+    assert raw_etype == 1
 
 
 @pytest.mark.parametrize(
@@ -177,6 +204,12 @@ def test_tsv_emodels_indices(circuit_mvd3_tsv):
     assert emodels[2] == "L6_cADpyr_471819401"
 
 
+def test_mvd3_mecombos_value(circuit_mvd3_tsv):
+    me_combo = circuit_mvd3_tsv.me_combos(9)
+
+    assert me_combo == "dSTUT_1_87dd39e6b0255ec053001f16da85b0e0"
+
+
 def test_mvd3_mecombos_indices(circuit_mvd3_tsv):
     me_combos = circuit_mvd3_tsv.me_combos([0,9,33])
 
@@ -192,12 +225,30 @@ def test_tsv_threshold_current(circuit_mvd3_tsv):
     assert threshold_currents[9] == 0
     assert threshold_currents[33] == 0.2
 
+
 def test_tsv_holding_current(circuit_mvd3_tsv):
     holding_currents = circuit_mvd3_tsv.holding_currents()
 
     assert holding_currents[0] == 0
     assert holding_currents[9] == 0.1
     assert holding_currents[33] == 0.15
+
+
+def test_tsv_pybind_api(circuit_mvd3_tsv):
+    holding_current = circuit_mvd3_tsv.holding_currents(0)
+
+    assert holding_current == 0
+    assert type(holding_current) is float
+
+    holding_currents = circuit_mvd3_tsv.holding_currents(0,10)
+
+    assert holding_currents[9] == 0.1
+    assert len(holding_currents) == 10
+
+    holding_currents = circuit_mvd3_tsv.holding_currents()
+
+    assert holding_currents[33] == 0.15
+    assert len(holding_currents) == 34
 
 
 @pytest.fixture
@@ -226,6 +277,13 @@ def test_layers(circuit_new_sonata):
     assert layers[0] == "SR"
     assert layers[42] == "SP"
     assert layers[2615] == "SO"
+
+
+def test_layer(circuit_new_sonata):
+    layer = circuit_new_sonata.layers(42)
+
+    assert layer == "SP"
+    assert type(layer) is str
 
 
 def test_list_allLayers(circuit_new_sonata):

--- a/python/test/test_mvd3.py
+++ b/python/test/test_mvd3.py
@@ -27,6 +27,26 @@ def test_position_values(circuit):
     assert posics.shape[0] == 1000
     assert numpy.allclose(posics[0], [40.821_401, 1986.506_637, 10.788_424])
 
+    posics = circuit.positions(0, 0)
+    assert posics.shape[0] == 1000
+    assert numpy.allclose(posics[0], [40.821_401, 1986.506_637, 10.788_424])
+
+    posic = circuit.positions(995)
+    assert posic.shape[0] == 1
+    assert numpy.allclose(posic, posics[995])
+
+    posics_995 = circuit.positions(995, 0)
+    assert posics_995.shape[0] == 5
+    assert numpy.allclose(posics_995[0], posics[995])
+
+    posics_995 = circuit.positions(995, 1)
+    assert posics_995.shape[0] == 1
+    assert numpy.allclose(posics_995[0], posics[995])
+
+    posics_995 = circuit.positions(995, 3)
+    assert posics_995.shape[0] == 3
+    assert numpy.allclose(posics_995[2], posics[997])
+
 
 def test_position_value(circuit):
     posic_0 = circuit.positions(0)
@@ -99,9 +119,30 @@ def test_etype_values_indices(circuit):
 
 
 def test_etype_values_ranges(circuit):
-    etypes = circuit.etypes(20, 10)
-    assert len(etypes) == 10
-    assert etypes[0] == "cADpyr"
+    etypes = circuit.etypes()
+    assert len(etypes) == 1000
+    assert etypes[0] == "cACint"
+
+    etypes = circuit.etypes(0, 0)
+    assert len(etypes) == 1000
+    assert etypes[0] == "cACint"
+
+    etype = circuit.etypes(20)
+    assert type(etype) is str
+    assert etype == etypes[20]
+
+    etypes_20 = circuit.etypes(20, 0)
+    assert len(etypes_20) == 980
+    assert etypes_20[0] == etypes[20]
+
+    etypes_20 = circuit.etypes(20, 1)
+    assert type(etypes_20) is not str
+    assert len(etypes_20) == 1
+    assert etypes_20[0] == etypes[20]
+
+    etypes_20 = circuit.etypes(20, 10)
+    assert len(etypes_20) == 10
+    assert etypes_20[0] == etypes[20]
 
 
 def test_mtype_values(circuit):
@@ -196,6 +237,33 @@ def test_tsv_emodels(circuit_mvd3_tsv):
     assert emodels[33] == "L6_cADpyr_471819401"
 
 
+def test_tsv_emodels_ranges(circuit_mvd3_tsv):
+    emodels = circuit_mvd3_tsv.emodels()
+    assert len(emodels) == 34
+    assert emodels[0] == "bAC_327962063"
+
+    emodels = circuit_mvd3_tsv.emodels(0, 0)
+    assert len(emodels) == 34
+    assert emodels[0] == "bAC_327962063"
+
+    emodel = circuit_mvd3_tsv.emodels(9)
+    assert type(emodel) is str
+    assert emodel == emodels[9]
+
+    emodels_9 = circuit_mvd3_tsv.emodels(9, 0)
+    assert len(emodels_9) == 25
+    assert emodels_9[0] == emodels[9]
+
+    emodels_9 = circuit_mvd3_tsv.emodels(9, 1)
+    assert type(emodels_9) is not str
+    assert len(emodels_9) == 1
+    assert emodels_9[0] == emodels[9]
+
+    emodels_9 = circuit_mvd3_tsv.emodels(9, 10)
+    assert len(emodels_9) == 10
+    assert emodels_9[0] == emodels[9]
+
+
 def test_tsv_emodels_indices(circuit_mvd3_tsv):
     emodels = circuit_mvd3_tsv.emodels([0,9,33])
 
@@ -277,6 +345,33 @@ def test_layers(circuit_new_sonata):
     assert layers[0] == "SR"
     assert layers[42] == "SP"
     assert layers[2615] == "SO"
+
+
+def test_layers_ranges(circuit_new_sonata):
+    layers = circuit_new_sonata.layers()
+    assert len(layers) == 2616
+    assert layers[0] == "SR"
+
+    layers = circuit_new_sonata.layers(0, 0)
+    assert len(layers) == 2616
+    assert layers[0] == "SR"
+
+    layer = circuit_new_sonata.layers(42)
+    assert type(layer) is str
+    assert layer == layers[42]
+
+    layers_42 = circuit_new_sonata.layers(42, 0)
+    assert len(layers_42) == 2574
+    assert layers_42[0] == layers[42]
+
+    layers_42 = circuit_new_sonata.layers(42, 1)
+    assert type(layers_42) is not str
+    assert len(layers_42) == 1
+    assert layers_42[0] == layers[42]
+
+    layers_42 = circuit_new_sonata.layers(42, 10)
+    assert len(layers_42) == 10
+    assert layers_42[0] == layers[20]
 
 
 def test_layer(circuit_new_sonata):

--- a/python/test/test_mvd3.py
+++ b/python/test/test_mvd3.py
@@ -237,8 +237,8 @@ def test_tsv_holding_current(circuit_mvd3_tsv):
 def test_tsv_pybind_api(circuit_mvd3_tsv):
     holding_current = circuit_mvd3_tsv.holding_currents(0)
 
-    assert holding_current == 0
     assert type(holding_current) is float
+    assert holding_current == 0
 
     holding_currents = circuit_mvd3_tsv.holding_currents(0,10)
 


### PR DESCRIPTION
- When pybind functions are called with one argument return the object
  in this offset
- Avoid accessing memory out of bounds when range.count == 0
- Fixes #70