### PR TITLE
Setting minimum req cxx standard to 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,12 @@ include(PackageConfig)
 FILE(GLOB MVDTOOL_HEADERS "include/mvdtool/*.hpp")
 FILE(GLOB MVDTOOLE_BITS_HEADERS "include/mvdtool/*/*.hpp")
 set(MVDTOOL_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_compile_options("-Wfatal-errors")
+
 
 if(BUILD_PYTHON_BINDINGS)
   add_subdirectory(python)


### PR DESCRIPTION
Some compilers, e.g. clang, still require this, otherwise will attempt to compile using c98 (and fail!)