### PR TITLE
Sprinkle some constexpr over the code.

### DIFF
--- a/include/mvdtool/bits/mvd3_misc.hpp
+++ b/include/mvdtool/bits/mvd3_misc.hpp
@@ -95,37 +95,37 @@ std::vector<T> tsv_get_chunked(const MVD3::MVD3File& mvd,
 
 
 // cells properties
-const std::string did_cells_positions = "/cells/positions";
-const std::string did_cells_rotations = "/cells/orientations";
+constexpr char did_cells_positions[] = "/cells/positions";
+constexpr char did_cells_rotations[] = "/cells/orientations";
 
 // cells properties namespace
-const std::string did_cells_hypercolumn = "/cells/properties/hypercolumn";
-const std::string did_cells_minicolmun = "/cells/properties/minicolumn";
-const std::string did_cells_layer = "/cells/properties/layer";
-const std::string did_cells_exc_mini_freq = "/cells/properties/exc_mini_frequency";
-const std::string did_cells_inh_mini_freq = "/cells/properties/inh_mini_frequency";
+constexpr char did_cells_hypercolumn[] = "/cells/properties/hypercolumn";
+constexpr char did_cells_minicolmun[] = "/cells/properties/minicolumn";
+constexpr char did_cells_layer[] = "/cells/properties/layer";
+constexpr char did_cells_exc_mini_freq[] = "/cells/properties/exc_mini_frequency";
+constexpr char did_cells_inh_mini_freq[] = "/cells/properties/inh_mini_frequency";
 
 // cells index
-const std::string did_cells_index_morpho = "/cells/properties/morphology";
-const std::string did_cells_index_etypes = "/cells/properties/etype";
-const std::string did_cells_index_mtypes = "/cells/properties/mtype";
-const std::string did_cells_index_mecombo = "/cells/properties/me_combo";
-const std::string did_cells_index_regions = "/cells/properties/region";
-const std::string did_cells_index_synapse_class = "/cells/properties/synapse_class";
+constexpr char did_cells_index_morpho[] = "/cells/properties/morphology";
+constexpr char did_cells_index_etypes[] = "/cells/properties/etype";
+constexpr char did_cells_index_mtypes[] = "/cells/properties/mtype";
+constexpr char did_cells_index_mecombo[] = "/cells/properties/me_combo";
+constexpr char did_cells_index_regions[] = "/cells/properties/region";
+constexpr char did_cells_index_synapse_class[] = "/cells/properties/synapse_class";
 
 // data
-const std::string did_lib_data_morpho = "/library/morphology";
-const std::string did_lib_data_etypes = "/library/etype";
-const std::string did_lib_data_mtypes = "/library/mtype";
-const std::string did_lib_data_mecombo = "/library/me_combo";
-const std::string did_lib_data_regions = "/library/region";
-const std::string did_lib_data_syn_class = "/library/synapse_class";
+constexpr char did_lib_data_morpho[] = "/library/morphology";
+constexpr char did_lib_data_etypes[] = "/library/etype";
+constexpr char did_lib_data_mtypes[] = "/library/mtype";
+constexpr char did_lib_data_mecombo[] = "/library/me_combo";
+constexpr char did_lib_data_regions[] = "/library/region";
+constexpr char did_lib_data_syn_class[] = "/library/synapse_class";
 
-const std::string did_lib_NONE = "";
+constexpr char did_lib_NONE[] = "";
 const MVD::Range range_ALL(0, 0);
 
 // circuit
-const std::string did_lib_circuit_seeds = "/circuit/seeds";
+constexpr char did_lib_circuit_seeds[] = "/circuit/seeds";
 
 using vec_string = std::vector<std::string>;
 

--- a/include/mvdtool/bits/mvd3_misc.hpp
+++ b/include/mvdtool/bits/mvd3_misc.hpp
@@ -93,6 +93,8 @@ std::vector<T> tsv_get_chunked(const MVD3::MVD3File& mvd,
     return output;
 }
 
+// Use constexpr char[] as const std::string is initialized too late for
+// static objects using MVD::File in certain cases
 
 // cells properties
 constexpr char did_cells_positions[] = "/cells/positions";

--- a/include/mvdtool/bits/sonata_misc.hpp
+++ b/include/mvdtool/bits/sonata_misc.hpp
@@ -34,20 +34,20 @@ using namespace bbp;
 using namespace MVD::utils;
 
 // Naming convention
-const std::string default_population_name = "default";
-const std::string did_layer = "layer";
-const std::string did_exc_mini_freq = "exc_mini_frequency";
-const std::string did_inh_mini_freq = "inh_mini_frequency";
-const std::string did_morpho = "morphology";
-const std::string did_etypes = "etype";
-const std::string did_mtypes = "mtype";
-const std::string did_emodel = "model_template";
-const std::string did_regions = "region";
-const std::string did_synapse_class = "synapse_class";
+constexpr char default_population_name[] = "default";
+constexpr char did_layer[] = "layer";
+constexpr char did_exc_mini_freq[] = "exc_mini_frequency";
+constexpr char did_inh_mini_freq[] = "inh_mini_frequency";
+constexpr char did_morpho[] = "morphology";
+constexpr char did_etypes[] = "etype";
+constexpr char did_mtypes[] = "mtype";
+constexpr char did_emodel[] = "model_template";
+constexpr char did_regions[] = "region";
+constexpr char did_synapse_class[] = "synapse_class";
 
-const std::string did_threshold_current = "threshold_current";
-const std::string did_holding_current = "holding_current";
-const std::string did_model_template = "model_template";
+constexpr char did_threshold_current[] = "threshold_current";
+constexpr char did_holding_current[] = "holding_current";
+constexpr char did_model_template[] = "model_template";
 
 inline auto select(const MVD::Range& range, size_t size) {
     return sonata::Selection({{range.offset, range.calculate_end(size)}});

--- a/include/mvdtool/bits/sonata_misc.hpp
+++ b/include/mvdtool/bits/sonata_misc.hpp
@@ -34,6 +34,9 @@ using namespace bbp;
 using namespace MVD::utils;
 
 // Naming convention
+//
+// Use constexpr char[] as const std::string is initialized too late for
+// static objects using MVD::File in certain cases
 constexpr char default_population_name[] = "default";
 constexpr char did_layer[] = "layer";
 constexpr char did_exc_mini_freq[] = "exc_mini_frequency";

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -41,6 +41,14 @@ add_executable(test_mvd3 tests_mvd3.cpp)
 target_link_libraries(test_mvd3 Boost::unit_test_framework MVDTool)
 add_test(NAME test_parser_mvd3 COMMAND test_mvd3)
 
+# library
+add_library(test_library tests_library.cpp)
+target_link_libraries(test_library MVDTool)
+
+add_executable(test_encapsulation tests_encapsulation.cpp)
+target_link_libraries(test_encapsulation test_library Boost::unit_test_framework)
+add_test(NAME test_encapsulation COMMAND test_encapsulation)
+
 # sonata
 add_executable(test_sonata tests_sonata.cpp)
 target_link_libraries(test_sonata Boost::unit_test_framework MVDTool)

--- a/tests/unit/tests_encapsulation.cpp
+++ b/tests/unit/tests_encapsulation.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 Adrien Devresse <adrien.devresse@epfl.ch>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#define BOOST_TEST_MODULE mvd3Lib
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+#include "tests_library.hpp"
+
+static lib::Counter c;
+
+BOOST_AUTO_TEST_CASE( staticUse )
+{
+    BOOST_CHECK_EQUAL(c.n, 1000);
+}

--- a/tests/unit/tests_library.cpp
+++ b/tests/unit/tests_library.cpp
@@ -1,0 +1,7 @@
+#include <mvdtool/mvd_generic.hpp>
+
+#include "tests_library.hpp"
+
+size_t lib::Counter::size() {
+    return MVD::open(MVD3_FILENAME)->size();
+}

--- a/tests/unit/tests_library.hpp
+++ b/tests/unit/tests_library.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdlib>
+
+namespace lib {
+
+struct Counter {
+    size_t n;
+
+    Counter() : n(size()) {};
+
+    static size_t size();
+};
+
+}


### PR DESCRIPTION
Allows MVD::File et al to be used in static objects, where otherwise the
code would compile, but no values would be assigned to the dataset ids and runtime exceptions will be thrown.