### PR TITLE
Use the current source directory to determine version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 if(NOT MVDTool_VERSION)
     execute_process(COMMAND git describe --tags
-                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     RESULT_VARIABLE GIT_VERSION_FAILED
                     OUTPUT_VARIABLE GIT_PKG_VERSION_FULL
                     ERROR_VARIABLE GIT_VERSION_ERROR


### PR DESCRIPTION
Solves issues when used as a submodule. Note that this variable cannot
be PROJECT_SOURCE_DIRECTORY as project() has not yet been called.

See also BlueBrain/libsonata#78.