### PR TITLE
Don't catch constructor exceptions to rethrow

### DIFF
--- a/include/mvdtool/mvd_generic.hpp
+++ b/include/mvdtool/mvd_generic.hpp
@@ -65,11 +65,7 @@ inline std::shared_ptr<File> open(const std::string& filename,
         throw std::runtime_error("MVD2 not supported in the new MVD API");
     case MVDType::MVD3:
         mvdfile.reset(new MVD3::MVD3File(filename));
-        try {
-            mvdfile->size();  // triggers struct initialization
-        } catch (...) {
-            throw std::runtime_error("invalid MVD3 file");
-        }
+        mvdfile->size();  // triggers struct initialization
         break;
     default:
         mvdfile.reset(new SonataFile(filename, population));

--- a/include/mvdtool/mvd_generic.hpp
+++ b/include/mvdtool/mvd_generic.hpp
@@ -72,7 +72,14 @@ inline std::shared_ptr<File> open(const std::string& filename,
         }
         break;
     default:
-        mvdfile.reset(new SonataFile(filename, population));
+        try {
+            mvdfile.reset(new SonataFile(filename, population));
+        } catch(std::runtime_error& e) {
+            throw e;
+        } catch(...) {
+            throw std::runtime_error("Invalid Sonata File. Undefined exception");
+        }
+
         break;
     }
     return mvdfile;

--- a/include/mvdtool/mvd_generic.hpp
+++ b/include/mvdtool/mvd_generic.hpp
@@ -64,16 +64,16 @@ inline std::shared_ptr<File> open(const std::string& filename,
     case MVDType::MVD2:
         throw std::runtime_error("MVD2 not supported in the new MVD API");
     case MVDType::MVD3:
+        mvdfile.reset(new MVD3::MVD3File(filename));
         try {
-            mvdfile.reset(new MVD3::MVD3File(filename));
             mvdfile->size();
         } catch (...) {
             throw std::runtime_error("invalid MVD3 file");
         }
         break;
     default:
+        mvdfile.reset(new SonataFile(filename, population));
         try {
-            mvdfile.reset(new SonataFile(filename, population));
             mvdfile->size();
         } catch (...) {
             throw std::runtime_error("invalid Sonata file");

--- a/include/mvdtool/mvd_generic.hpp
+++ b/include/mvdtool/mvd_generic.hpp
@@ -66,18 +66,13 @@ inline std::shared_ptr<File> open(const std::string& filename,
     case MVDType::MVD3:
         mvdfile.reset(new MVD3::MVD3File(filename));
         try {
-            mvdfile->size();
+            mvdfile->size();  // triggers struct initialization
         } catch (...) {
             throw std::runtime_error("invalid MVD3 file");
         }
         break;
     default:
         mvdfile.reset(new SonataFile(filename, population));
-        try {
-            mvdfile->size();
-        } catch (...) {
-            throw std::runtime_error("invalid Sonata file");
-        }
         break;
     }
     return mvdfile;

--- a/include/mvdtool/mvd_generic.hpp
+++ b/include/mvdtool/mvd_generic.hpp
@@ -72,14 +72,7 @@ inline std::shared_ptr<File> open(const std::string& filename,
         }
         break;
     default:
-        try {
-            mvdfile.reset(new SonataFile(filename, population));
-        } catch(std::runtime_error& e) {
-            throw e;
-        } catch(...) {
-            throw std::runtime_error("Invalid Sonata File. Undefined exception");
-        }
-
+        mvdfile.reset(new SonataFile(filename, population));
         break;
     }
     return mvdfile;


### PR DESCRIPTION
Following BBPBGLIB-613, this ticket avoids an original exception from being caught, thus passing on the original message, even to python layers.